### PR TITLE
fix the change in svelte kit builder api

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,50 +1,63 @@
+import { fixPages } from "./lib.js";
 
-import {fixPages} from './lib.js';
-
-import { createReadStream, createWriteStream, statSync } from 'fs';
-import { pipeline } from 'stream';
-import glob from 'tiny-glob';
-import { promisify } from 'util';
-import zlib from 'zlib';
+import { createReadStream, createWriteStream, statSync } from "fs";
+import { pipeline } from "stream";
+import glob from "tiny-glob";
+import { promisify } from "util";
+import zlib from "zlib";
 
 const pipe = promisify(pipeline);
 
-
 /** @type {import('.')} */
-export default function ({ pages = 'build', assets = pages, fallback, precompress = false, callbacks = undefined, copyBeforeSourceMapRemoval = undefined, removeSourceMap = false, removeBuiltInServiceWorkerRegistration = false, injectPagesInServiceWorker = false, injectDebugConsole = false  } = {}) {
-	const adapter = {
-		name: 'sveltejs-adapter-ipfs',
+export default function ({
+  pages = "build",
+  assets = pages,
+  fallback,
+  precompress = false,
+  callbacks = undefined,
+  copyBeforeSourceMapRemoval = undefined,
+  removeSourceMap = false,
+  removeBuiltInServiceWorkerRegistration = false,
+  injectPagesInServiceWorker = false,
+  injectDebugConsole = false,
+} = {}) {
+  const adapter = {
+    name: "sveltejs-adapter-ipfs",
 
-		async adapt(builder) {
-			builder.rimraf(assets);
-			builder.rimraf(pages);
+    async adapt(builder) {
+      builder.rimraf(assets);
+      builder.rimraf(pages);
 
-			builder.writeStatic(assets);
-			builder.writeClient(assets);
-
-			await builder.prerender({
-				fallback,
-				all: !fallback,
-				dest: pages
-			});
+      builder.writeStatic(assets);
+      builder.writeClient(assets);
+      builder.writePrerendered(pages, { fallback });
 
       // before compress or after ?
-      await fixPages({pages, assets, callbacks, copyBeforeSourceMapRemoval, removeSourceMap, removeBuiltInServiceWorkerRegistration, injectPagesInServiceWorker, injectDebugConsole});
+      await fixPages({
+        pages,
+        assets,
+        callbacks,
+        copyBeforeSourceMapRemoval,
+        removeSourceMap,
+        removeBuiltInServiceWorkerRegistration,
+        injectPagesInServiceWorker,
+        injectDebugConsole,
+      });
 
-			if (precompress) {
-				if (pages === assets) {
-					builder.log.minor('Compressing assets and pages');
-					await compress(assets);
-				} else {
-					builder.log.minor('Compressing assets');
-					await compress(assets);
+      if (precompress) {
+        if (pages === assets) {
+          builder.log.minor("Compressing assets and pages");
+          await compress(assets);
+        } else {
+          builder.log.minor("Compressing assets");
+          await compress(assets);
 
-					builder.log.minor('Compressing pages');
-					await compress(pages);
-				}
-			}
-		}
-	};
+          builder.log.minor("Compressing pages");
+          await compress(pages);
+        }
+      }
+    },
+  };
   return adapter;
 }
 
@@ -52,37 +65,39 @@ export default function ({ pages = 'build', assets = pages, fallback, precompres
  * @param {string} directory
  */
 async function compress(directory) {
-	const files = await glob('**/*.{html,js,json,css,svg,xml}', {
-		cwd: directory,
-		dot: true,
-		absolute: true,
-		filesOnly: true
-	});
+  const files = await glob("**/*.{html,js,json,css,svg,xml}", {
+    cwd: directory,
+    dot: true,
+    absolute: true,
+    filesOnly: true,
+  });
 
-	await Promise.all(
-		files.map((file) => Promise.all([compress_file(file, 'gz'), compress_file(file, 'br')]))
-	);
+  await Promise.all(
+    files.map((file) =>
+      Promise.all([compress_file(file, "gz"), compress_file(file, "br")])
+    )
+  );
 }
 
 /**
  * @param {string} file
  * @param {'gz' | 'br'} format
  */
-async function compress_file(file, format = 'gz') {
-	const compress =
-		format == 'br'
-			? zlib.createBrotliCompress({
-					params: {
-						[zlib.constants.BROTLI_PARAM_MODE]: zlib.constants.BROTLI_MODE_TEXT,
-						[zlib.constants.BROTLI_PARAM_QUALITY]: zlib.constants.BROTLI_MAX_QUALITY,
-						[zlib.constants.BROTLI_PARAM_SIZE_HINT]: statSync(file).size
-					}
-			  })
-			: zlib.createGzip({ level: zlib.constants.Z_BEST_COMPRESSION });
+async function compress_file(file, format = "gz") {
+  const compress =
+    format == "br"
+      ? zlib.createBrotliCompress({
+          params: {
+            [zlib.constants.BROTLI_PARAM_MODE]: zlib.constants.BROTLI_MODE_TEXT,
+            [zlib.constants.BROTLI_PARAM_QUALITY]:
+              zlib.constants.BROTLI_MAX_QUALITY,
+            [zlib.constants.BROTLI_PARAM_SIZE_HINT]: statSync(file).size,
+          },
+        })
+      : zlib.createGzip({ level: zlib.constants.Z_BEST_COMPRESSION });
 
-	const source = createReadStream(file);
-	const destination = createWriteStream(`${file}.${format}`);
+  const source = createReadStream(file);
+  const destination = createWriteStream(`${file}.${format}`);
 
-	await pipe(source, compress, destination);
+  await pipe(source, compress, destination);
 }
-


### PR DESCRIPTION
This fixes the following error 
```
> Using sveltejs-adapter-ipfs
> builder.prerender() has been removed. Prerendering now takes place in the build phase — see builder.prerender and builder.writePrerendered
```
![image](https://user-images.githubusercontent.com/80440/165783960-804ce62f-21e0-431e-b256-fb8aca90f27f.png)

Here is the proof that it works 
![image](https://user-images.githubusercontent.com/80440/165783896-d6b31852-4b1e-42dc-af45-fcd912ec225a.png)
