### PR TITLE
fix #8 builder.writeClient has replace writeStatic

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,7 +28,6 @@ export default function ({
       builder.rimraf(assets);
       builder.rimraf(pages);
 
-      builder.writeStatic(assets);
       builder.writeClient(assets);
       builder.writePrerendered(pages, { fallback });
 

--- a/package.json
+++ b/package.json
@@ -13,12 +13,12 @@
     "tiny-glob": "^0.2.9"
   },
   "devDependencies": {
-		"@sveltejs/kit": "^1.0.0-next.212",
+    "@sveltejs/kit": "^1.0.0-next.212",
     "@types/fs-extra": "^9.0.11",
-		"playwright-chromium": "^1.17.0",
-		"port-authority": "^1.1.2",
-		"sirv": "^1.0.19",
-		"svelte": "^3.44.2",
+    "playwright-chromium": "^1.17.0",
+    "port-authority": "^1.1.2",
+    "sirv": "^1.0.19",
+    "svelte": "^3.44.2",
     "uvu": "^0.5.2"
   },
   "scripts": {


### PR DESCRIPTION
As mentioned in https://github.com/sveltejs/kit/pull/5618 `builder.writeClient` now writes both the client and static files, which resulted in the removal of `builder.writeStatic`.